### PR TITLE
Remove empty version CI

### DIFF
--- a/.github/workflows/main-ci.yaml
+++ b/.github/workflows/main-ci.yaml
@@ -15,9 +15,6 @@ jobs:
           - ubuntu-22.04-arm
           - macos-latest
           - windows-latest
-        version:
-          - ""
-          - "v0.1.0-alpha6"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -28,7 +25,5 @@ jobs:
           cache: false
       - name: GoCICa action
         uses: ./
-        with:
-          version: ${{ matrix.version }}
       - name: Build standard library
         run: go install std


### PR DESCRIPTION
This pull request includes changes to the CI configuration in the `.github/workflows/main-ci.yaml` file. The most important changes involve simplifying the job matrix by removing the version matrix and its usage in the `GoCICa` action.

CI configuration simplification:

* [`.github/workflows/main-ci.yaml`](diffhunk://#diff-b0d5efbc98f2beec0f86a1de733c7d2f3a459fea85cbfc2d2baa9ba3e9da2f03L18-L20): Removed the `version` matrix from the job configuration.
* [`.github/workflows/main-ci.yaml`](diffhunk://#diff-b0d5efbc98f2beec0f86a1de733c7d2f3a459fea85cbfc2d2baa9ba3e9da2f03L31-L32): Removed the `version` input from the `GoCICa` action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined our automated process configuration to simplify operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->