### PR TITLE
Update GoCICa v0.1.0-alpha7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
       The version of GoCICa to use.
       If not specified, the latest version will be used.
     required: false
-    default: 'v0.1.0-alpha6'
+    default: 'v0.1.0-alpha7'
   dir:
     description: 'Directory to store cache files'
     required: false


### PR DESCRIPTION
This pull request includes a small change to the `action.yml` file. The change updates the default version of GoCICa from 'v0.1.0-alpha6' to 'v0.1.0-alpha7'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the default GoCICa version from v0.1.0-alpha6 to v0.1.0-alpha7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->